### PR TITLE
Add new `createdSubmission` callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,19 @@ protected function submittingForm(): void
 }
 ```
 
+#### Created Submission
+
+Use this callback to modify the data of the submission before it gets saved and events are triggered.
+
+```php
+protected function createdSubmission(Submission $submission): void
+{
+    $title = $submission->augmentedValue('entry')->value()->title;
+
+    $submission->set('entry_title', $title);
+}
+```
+
 #### Submitted Form
 
 Use this hook to perform an action after the form has been submitted.

--- a/resources/stubs/DummyForm.php
+++ b/resources/stubs/DummyForm.php
@@ -54,6 +54,13 @@ class DummyForm extends BaseForm
     //     $this->data['success'] = true;
     // }
 
+    // protected function createdSubmission(Submission $submission): void
+    // {
+    //     $title = $submission->augmentedValue('entry')->value()->title;
+    //
+    //     $submission->set('entry_title', $title);
+    // }
+
     // protected function submittedForm(): void
     // {
     //     Newsletter::subscribe($this->data['email']);

--- a/src/Http/Livewire/BaseForm.php
+++ b/src/Http/Livewire/BaseForm.php
@@ -158,6 +158,7 @@ class BaseForm extends Component
         return $this
             ->runSubmittingFormHook()
             ->makeSubmission()
+            ->runCreatedSubmissionFormHook()
             ->handleSubmissionEvents()
             ->storeSubmission()
             ->runSubmittedFormHook();
@@ -181,6 +182,13 @@ class BaseForm extends Component
         return $this;
     }
 
+    protected function runCreatedSubmissionFormHook(): self
+    {
+        $this->createdSubmission($this->submission);
+
+        return $this;
+    }
+
     protected function runSubmittedFormHook(): self
     {
         $this->submittedForm();
@@ -189,6 +197,11 @@ class BaseForm extends Component
     }
 
     protected function submittingForm(): void
+    {
+        //
+    }
+
+    protected function createdSubmission(Submission $submission): void
     {
         //
     }


### PR DESCRIPTION
This PR adds a new `createdSubmission` callback. This can be useful if you want to modify the submission before it gets saved.