### PR TITLE
Hide label for hidden input field

### DIFF
--- a/resources/stubs/theme/fields/input.blade.php
+++ b/resources/stubs/theme/fields/input.blade.php
@@ -1,4 +1,4 @@
-@if ($field->show_label)
+@if ($field->show_label && $field->input_type !== 'hidden')
     <div class="mb-1">
         <label for="{{ $field->id }}" class="block text-sm font-medium text-gray-700">
             {{ $field->label }}


### PR DESCRIPTION
Hidden text inputs don't require labels, this change would hide the label area when the field type is "hidden".