### PR TITLE
Hide text field with `input_type: hidden`

### DIFF
--- a/src/Fields/Text.php
+++ b/src/Fields/Text.php
@@ -13,4 +13,13 @@ class Text extends Field
     use WithPlaceholder;
 
     protected static string $view = 'input';
+
+    protected function showProperty(): bool
+    {
+        if ($this->inputTypeProperty() === 'hidden') {
+            return false;
+        }
+
+        return parent::showProperty();
+    }
 }


### PR DESCRIPTION
This PR replaces PR #23. If a text field has `input_type: hidden`, it will be removed from the frontend. This is the same behavior as when using the `Hidden` fieldtype.

I first thought that it might be a good idea to NOT remove hidden fields from the frontend but simply hide them with CSS. This would allow manipulating a field's value with JS. However, I completely forgot that this approach doesn't work due to Livewire's security measures. If you want to manipulate a field's value, you have to do it within the Livewire component. And the field doesn't have to be present on the frontend to change its value.