### PR TITLE
Don’t submit values of hidden fields

### DIFF
--- a/src/Http/Livewire/BaseForm.php
+++ b/src/Http/Livewire/BaseForm.php
@@ -249,6 +249,10 @@ class BaseForm extends Component
                 return (int) $value;
             }
 
+            if (! $field->show && ! $field->always_save) {
+                return null;
+            }
+
             return $value;
         })->all();
     }


### PR DESCRIPTION
This PR introduces the same [field data flow](https://statamic.dev/fields#field-data-flow) that Statamic uses for conditional fields. Conditionally hidden fields won't be added to the form submission anymore. If you want to submit the value of a hidden field, you can add `always_save: true` to the field in question.

This change is useful to keep your submission data clean of any values that should have not been submitted. A user might have activated a checkbox to show a field. Filled in that field, but then decided to deactivate the checkbox again. Without this PR, you woule still get the value of the filled in field, which should now have been removed.

This behavior is technically a breaking change, as some users might rely on all values to be submitted.