### PR TITLE
Allow for more complex field validation scenarios

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -53,6 +53,16 @@ abstract class Field
         return $this->field;
     }
 
+    public function rules(): array
+    {
+        return [$this->key => $this->rules];
+    }
+
+    public function validationAttributes(): array
+    {
+        return [$this->key => $this->label];
+    }
+
     protected function get(string $key): mixed
     {
         $method = collect(get_class_methods($this))

--- a/src/Form/Fields.php
+++ b/src/Form/Fields.php
@@ -149,14 +149,14 @@ class Fields
     public function validationRules(): array
     {
         return $this->fields
-            ->mapWithKeys(fn ($field) => [$field->key => $field->rules])
+            ->mapWithKeys(fn ($field) => $field->rules())
             ->toArray();
     }
 
     public function validationAttributes(): array
     {
         return $this->fields
-            ->mapWithKeys(fn ($field) => [$field->key => $field->label])
+            ->mapWithKeys(fn ($field) => $field->validationAttributes())
             ->toArray();
     }
 


### PR DESCRIPTION
This PR moves the `rules` and `validationAttributes` into the `Field` class. This allows for better control of the validation of a field. 

I came across this issue when working on a field model for the Grid fieldtype that deals with an array of data. The current implementation didn't allow for this scenario. Now you can simply override the default `rules` and `validationAttributes` methods if needed.

```php
public function rules(): array
{
    return [
        "{$this->key}" => 'required|array',
        "{$this->key}.*.issue" => 'required|string',
        "{$this->key}.*.amount" => 'required|integer|min:1',
    ];
}

public function validationAttributes(): array
{
    return [
        "{$this->key}" => 'Ausgaben',
        "{$this->key}.*.issue" => 'Ausgabe',
        "{$this->key}.*.amount" => 'Anzahl',
    ];
}
```