### PR TITLE
Always save value of Hidden fields

### DIFF
--- a/src/Fields/Hidden.php
+++ b/src/Fields/Hidden.php
@@ -6,6 +6,11 @@ class Hidden extends Field
 {
     protected static string $view = 'input';
 
+    protected function alwaysSaveProperty(): bool
+    {
+        return true;
+    }
+
     protected function showProperty(): bool
     {
         return false;


### PR DESCRIPTION
PR https://github.com/aerni/statamic-livewire-forms/pull/30 introduced the same field data flow Statamic uses for conditional fields. This is great not to submit values of conditionally hidden fields. However, it requires that you add `always_save: true` to submit the values of Hidden fields. I got confused a couple of times as to why no value was saved and frankly find this behavior quite annoying.

With this PR, the value of Hidden fields will be saved. Hidden fields are usually used to submit some additional values, e.g. some ID or the locale of the site. I believe this is the behavior a user expects of a Hidden field. I can't think of any other scenario where you would use a hidden field but not want to save its value.