### PR TITLE
Fix processing of asset fields with `max_files: 1`

### DIFF
--- a/src/Fields/Assets.php
+++ b/src/Fields/Assets.php
@@ -67,7 +67,8 @@ class Assets extends Field
     public function process(): mixed
     {
         $this->value = collect($this->value)
-            ->flatMap(fn ($file) => AssetsUploader::field($this->field)->upload($file));
+            ->map(fn ($file) => AssetsUploader::field($this->field)->upload($file))
+            ->flatten();
 
         return parent::process();
     }


### PR DESCRIPTION
This PR closes #58.