### PR TITLE
Publish component to configured Livewire namespace

### DIFF
--- a/src/Commands/form.stub
+++ b/src/Commands/form.stub
@@ -1,13 +1,13 @@
 <?php
 
-namespace App\Livewire;
+namespace [namespace];
 
 use Aerni\LivewireForms\Form\Fields;
 use Aerni\LivewireForms\Livewire\BaseForm;
 use Illuminate\Support\Collection;
 use Statamic\Contracts\Forms\Submission;
 
-class [className] extends BaseForm
+class [class] extends BaseForm
 {
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
This PR ensures that the `livewire-forms:component` command publishes the component to the `class_namespace` configured in the `livewire.php` config.