### PR TITLE
Load scoped form localizations from vendor lang

### DIFF
--- a/src/Livewire/Concerns/WithMessages.php
+++ b/src/Livewire/Concerns/WithMessages.php
@@ -8,22 +8,40 @@ trait WithMessages
 {
     public function successMessage(): string
     {
-        return Lang::has("livewire-forms.{$this->handle}.success_message")
-            ? __("livewire-forms.{$this->handle}.success_message")
-            : __('livewire-forms::messages.success_message');
+        if (Lang::has("livewire-forms.{$this->handle}.success_message")) {
+            return __("livewire-forms.{$this->handle}.success_message");
+        }
+
+        if (Lang::has("livewire-forms::messages.{$this->handle}.success_message")) {
+            return __("livewire-forms::messages.{$this->handle}.success_message");
+        }
+
+        return __('livewire-forms::messages.success_message');
     }
 
     public function errorMessage(): string
     {
-        return Lang::has("livewire-forms.{$this->handle}.error_message")
-            ? trans_choice("livewire-forms.{$this->handle}.error_message", $this->getErrorBag()->count())
-            : trans_choice('livewire-forms::messages.error_message', $this->getErrorBag()->count());
+        if (Lang::has("livewire-forms.{$this->handle}.error_message")) {
+            return trans_choice("livewire-forms.{$this->handle}.error_message", $this->getErrorBag()->count());
+        }
+
+        if (Lang::has("livewire-forms::messages.{$this->handle}.error_message")) {
+            return trans_choice("livewire-forms::messages.{$this->handle}.error_message", $this->getErrorBag()->count());
+        }
+
+        return trans_choice('livewire-forms::messages.error_message', $this->getErrorBag()->count());
     }
 
     public function submitButtonLabel(): string
     {
-        return Lang::has("livewire-forms.{$this->handle}.submit_button_label")
-            ? __("livewire-forms.{$this->handle}.submit_button_label")
-            : __('livewire-forms::messages.submit_button_label');
+        if (Lang::has("livewire-forms.{$this->handle}.submit_button_label")) {
+            return __("livewire-forms.{$this->handle}.submit_button_label");
+        }
+
+        if (Lang::has("livewire-forms::messages.{$this->handle}.submit_button_label")) {
+            return __("livewire-forms::messages.{$this->handle}.submit_button_label");
+        }
+
+        return __('livewire-forms::messages.submit_button_label');
     }
 }


### PR DESCRIPTION
This PR adds the ability to load scoped form localizations from the vendor folder, rather than relying on an additional language file. The previous behavior is retained as to not make this a breaking change.