### PR TITLE
Add config options to control panel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "laravel/prompts": "^0.1.13",
         "livewire/livewire": "^3.2",
         "spatie/invade": "^2.0",
-        "statamic/cms": "^5.22"
+        "statamic/cms": "^5.36"
     },
     "require-dev": {
         "orchestra/testbench": "^8.19",

--- a/src/Livewire/Concerns/WithRedirect.php
+++ b/src/Livewire/Concerns/WithRedirect.php
@@ -2,10 +2,22 @@
 
 namespace Aerni\LivewireForms\Livewire\Concerns;
 
+use Illuminate\Support\Str;
+use Statamic\Facades\Entry;
 use Livewire\Attributes\Locked;
 
 trait WithRedirect
 {
     #[Locked]
-    public string $redirect = '';
+    public string $redirect;
+
+    public function mountWithRedirect(): void
+    {
+        $this->redirect ??= $this->form->redirect ?? '';
+
+        /* This is a workaround because the form config fields are not augmented. So we have to manually get the entry. */
+        if (Str::startsWith($this->redirect, 'entry::')) {
+            $this->redirect = Entry::find(Str::after($this->redirect, 'entry::'))?->permalink ?? '';
+        }
+    }
 }

--- a/src/Livewire/Concerns/WithRedirect.php
+++ b/src/Livewire/Concerns/WithRedirect.php
@@ -3,8 +3,8 @@
 namespace Aerni\LivewireForms\Livewire\Concerns;
 
 use Illuminate\Support\Str;
-use Statamic\Facades\Entry;
 use Livewire\Attributes\Locked;
+use Statamic\Facades\Entry;
 
 trait WithRedirect
 {

--- a/src/Livewire/Concerns/WithTheme.php
+++ b/src/Livewire/Concerns/WithTheme.php
@@ -22,6 +22,11 @@ trait WithTheme
             return $this->theme;
         }
 
+        /* Use the theme configured in the form config if it exists. */
+        if (ViewManager::themeExists($this->form->theme)) {
+            return $this->form->theme;
+        }
+
         /* Autoload the theme by form handle if it exists. */
         if (ViewManager::themeExists($this->handle)) {
             return $this->handle;

--- a/src/Livewire/Concerns/WithType.php
+++ b/src/Livewire/Concerns/WithType.php
@@ -16,7 +16,7 @@ trait WithType
 
     protected function type(): string
     {
-        return match ($this->type ?? null) {
+        return match ($this->type ?? $this->form->type) {
             'wizard' => 'wizard',
             default => 'basic',
         };

--- a/src/Livewire/Concerns/WithView.php
+++ b/src/Livewire/Concerns/WithView.php
@@ -22,6 +22,11 @@ trait WithView
             return $this->view;
         }
 
+        /* Use the view configured in the form config if it exists. */
+        if (ViewManager::viewExists($this->form->view)) {
+            return $this->form->view;
+        }
+
         /* Autoload the view by form handle if it exists. */
         if (ViewManager::viewExists($this->handle)) {
             return $this->handle;

--- a/src/Livewire/DynamicForm.php
+++ b/src/Livewire/DynamicForm.php
@@ -2,18 +2,20 @@
 
 namespace Aerni\LivewireForms\Livewire;
 
-use Aerni\LivewireForms\Livewire\Concerns\WithComponent;
-use Aerni\LivewireForms\Livewire\Concerns\WithHandle;
-use Aerni\LivewireForms\Livewire\Concerns\WithRedirect;
-use Aerni\LivewireForms\Livewire\Concerns\WithTheme;
+use Livewire\Component;
+use Illuminate\Contracts\View\View;
+use Aerni\LivewireForms\Livewire\Concerns\WithForm;
 use Aerni\LivewireForms\Livewire\Concerns\WithType;
 use Aerni\LivewireForms\Livewire\Concerns\WithView;
-use Illuminate\Contracts\View\View;
-use Livewire\Component;
+use Aerni\LivewireForms\Livewire\Concerns\WithTheme;
+use Aerni\LivewireForms\Livewire\Concerns\WithHandle;
+use Aerni\LivewireForms\Livewire\Concerns\WithRedirect;
+use Aerni\LivewireForms\Livewire\Concerns\WithComponent;
 
 class DynamicForm extends Component
 {
     use WithComponent;
+    use WithForm;
     use WithHandle;
     use WithTheme;
     use WithType;

--- a/src/Livewire/DynamicForm.php
+++ b/src/Livewire/DynamicForm.php
@@ -2,15 +2,15 @@
 
 namespace Aerni\LivewireForms\Livewire;
 
-use Livewire\Component;
-use Illuminate\Contracts\View\View;
+use Aerni\LivewireForms\Livewire\Concerns\WithComponent;
 use Aerni\LivewireForms\Livewire\Concerns\WithForm;
-use Aerni\LivewireForms\Livewire\Concerns\WithType;
-use Aerni\LivewireForms\Livewire\Concerns\WithView;
-use Aerni\LivewireForms\Livewire\Concerns\WithTheme;
 use Aerni\LivewireForms\Livewire\Concerns\WithHandle;
 use Aerni\LivewireForms\Livewire\Concerns\WithRedirect;
-use Aerni\LivewireForms\Livewire\Concerns\WithComponent;
+use Aerni\LivewireForms\Livewire\Concerns\WithTheme;
+use Aerni\LivewireForms\Livewire\Concerns\WithType;
+use Aerni\LivewireForms\Livewire\Concerns\WithView;
+use Illuminate\Contracts\View\View;
+use Livewire\Component;
 
 class DynamicForm extends Component
 {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,18 +2,18 @@
 
 namespace Aerni\LivewireForms;
 
+use Aerni\LivewireForms\Facades\Captcha;
+use Aerni\LivewireForms\Livewire\BaseForm;
+use Aerni\LivewireForms\Livewire\DynamicForm;
+use Aerni\LivewireForms\Livewire\Synthesizers\FieldSynth;
+use Aerni\LivewireForms\Livewire\Synthesizers\RuleSynth;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
 use Livewire\Livewire;
 use Statamic\Facades\Form;
-use Illuminate\Support\Str;
-use Illuminate\Support\Facades\File;
-use Illuminate\Support\Facades\Blade;
-use Aerni\LivewireForms\Facades\Captcha;
-use Illuminate\Support\Facades\Validator;
-use Aerni\LivewireForms\Livewire\BaseForm;
 use Statamic\Providers\AddonServiceProvider;
-use Aerni\LivewireForms\Livewire\DynamicForm;
-use Aerni\LivewireForms\Livewire\Synthesizers\RuleSynth;
-use Aerni\LivewireForms\Livewire\Synthesizers\FieldSynth;
 
 class ServiceProvider extends AddonServiceProvider
 {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,15 +2,18 @@
 
 namespace Aerni\LivewireForms;
 
-use Aerni\LivewireForms\Facades\Captcha;
-use Aerni\LivewireForms\Livewire\BaseForm;
-use Aerni\LivewireForms\Livewire\DynamicForm;
-use Aerni\LivewireForms\Livewire\Synthesizers\FieldSynth;
-use Aerni\LivewireForms\Livewire\Synthesizers\RuleSynth;
-use Illuminate\Support\Facades\Blade;
-use Illuminate\Support\Facades\Validator;
 use Livewire\Livewire;
+use Statamic\Facades\Form;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Blade;
+use Aerni\LivewireForms\Facades\Captcha;
+use Illuminate\Support\Facades\Validator;
+use Aerni\LivewireForms\Livewire\BaseForm;
 use Statamic\Providers\AddonServiceProvider;
+use Aerni\LivewireForms\Livewire\DynamicForm;
+use Aerni\LivewireForms\Livewire\Synthesizers\RuleSynth;
+use Aerni\LivewireForms\Livewire\Synthesizers\FieldSynth;
 
 class ServiceProvider extends AddonServiceProvider
 {
@@ -35,7 +38,8 @@ class ServiceProvider extends AddonServiceProvider
             ->bootBladeDirectives()
             ->bootValidators()
             ->bootLivewire()
-            ->bootSelectableFieldtypes();
+            ->bootSelectableFieldtypes()
+            ->bootFormConfigFields();
     }
 
     protected function bootBladeDirectives(): self
@@ -70,6 +74,49 @@ class ServiceProvider extends AddonServiceProvider
     protected function bootSelectableFieldtypes(): self
     {
         \Statamic\Fieldtypes\Hidden::makeSelectableInForms();
+
+        return $this;
+    }
+
+    protected function bootFormConfigFields(): self
+    {
+        Form::appendConfigFields('*', __('Livewire Forms'), [
+            'type' => [
+                'type' => 'button_group',
+                'display' => __('Type'),
+                'instructions' => __('Choose the desired type for this form.'),
+                'options' => [
+                    'basic' => __('Basic'),
+                    'wizard' => __('Wizard'),
+                ],
+                'default' => 'basic',
+            ],
+            'view' => [
+                'type' => 'select',
+                'display' => __('View'),
+                'instructions' => __('Choose the view for this form.'),
+                'options' => collect(File::files(resource_path('views/'.config('livewire-forms.view_path'))))
+                    ->map(fn ($file) => Str::before($file->getBasename(), '.'))
+                    ->mapWithKeys(fn ($view) => [$view => str($view)->replace(['_', '-'], ' ')->title()->toString()]),
+                'clearable' => true,
+                'width' => 50,
+            ],
+            'theme' => [
+                'type' => 'select',
+                'display' => __('Theme'),
+                'instructions' => __('Choose the theme for this form.'),
+                'options' => collect(File::directories(resource_path('views/'.config('livewire-forms.view_path'))))
+                    ->map(fn ($directory) => basename($directory))
+                    ->mapWithKeys(fn ($theme) => [$theme => str($theme)->replace(['_', '-'], ' ')->title()->toString()]),
+                'clearable' => true,
+                'width' => 50,
+            ],
+            'redirect' => [
+                'type' => 'link',
+                'display' => __('Redirect URL'),
+                'instructions' => __('The users will be redirected to this URL after the form was submitted.'),
+            ],
+        ]);
 
         return $this;
     }

--- a/src/ViewManager.php
+++ b/src/ViewManager.php
@@ -22,13 +22,21 @@ class ViewManager
         return view()->exists($this->themeViewPath($theme, $view));
     }
 
-    public function viewExists(string $view): bool
+    public function viewExists(?string $view): bool
     {
+        if (empty($view)) {
+            return false;
+        }
+
         return view()->exists($this->viewPath($view));
     }
 
-    public function themeExists(string $theme): bool
+    public function themeExists(?string $theme): bool
     {
+        if (empty($theme)) {
+            return false;
+        }
+
         return is_dir(resource_path("views/{$this->viewPath($theme)}"));
     }
 


### PR DESCRIPTION
This PR adds the ability to configure Livewire Forms when configuring a form in the control panel. The available options mirror what's available as Livewire component parameters. Manually set parameters in the view, will take precedence over the configuration in the control panel.

![CleanShot 2024-10-31 at 16 02 26@2x](https://github.com/user-attachments/assets/556f19d7-f035-4707-a671-e396fcda045b)
