### PR TITLE
Never render hidden fields

### DIFF
--- a/src/Form/Section.php
+++ b/src/Form/Section.php
@@ -42,6 +42,8 @@ class Section
 
     public function fields(): Collection
     {
-        return Livewire::current()->fields->intersectByKeys(array_flip($this->fields));
+        return Livewire::current()->fields
+            ->intersectByKeys(array_flip($this->fields))
+            ->filter(fn ($field) => ! $field->hidden);
     }
 }

--- a/src/Form/Step.php
+++ b/src/Form/Step.php
@@ -45,7 +45,9 @@ class Step
 
     public function fields(): Collection
     {
-        return Livewire::current()->fields->intersectByKeys(array_flip($this->fields));
+        return Livewire::current()->fields
+            ->intersectByKeys(array_flip($this->fields))
+            ->filter(fn ($field) => ! $field->hidden);
     }
 
     public function isPrevious(): bool


### PR DESCRIPTION
This PR removes any field with the property `hidden` set to `true` from the DOM. Hidden fields were already hidden with Alpine and set to `display: none`. This PR simply cleans up the DOM as the fields won't ever be shown anyway.