### PR TITLE
Fix assets upload

### DIFF
--- a/src/Fields/Assets.php
+++ b/src/Fields/Assets.php
@@ -16,6 +16,12 @@ class Assets extends Field
 {
     protected string $view = 'assets';
 
+    protected function defaultProperty(mixed $default = null): array
+    {
+        /* We need to initialize the value to an empty array for the upload to work. */
+        return [];
+    }
+
     protected function multipleProperty(?bool $multiple = null): bool
     {
         return $multiple ?? $this->field->get('max_files') !== 1;


### PR DESCRIPTION
This PR closes #75 by initializing assets fields to an empty array. I'm not quite sure why it used to work without this change, but here we go.