### PR TITLE
Add Dictionary Fieldtype support

### DIFF
--- a/config/livewire-forms.php
+++ b/config/livewire-forms.php
@@ -15,6 +15,7 @@ return [
         Aerni\LivewireForms\Fieldtypes\Captcha::class => Aerni\LivewireForms\Fields\Captcha::class,
         Statamic\Fieldtypes\Assets\Assets::class => Aerni\LivewireForms\Fields\Assets::class,
         Statamic\Fieldtypes\Checkboxes::class => Aerni\LivewireForms\Fields\Checkboxes::class,
+        Statamic\Fieldtypes\Dictionary::class => Aerni\LivewireForms\Fields\Dictionary::class,
         Statamic\Fieldtypes\Hidden::class => Aerni\LivewireForms\Fields\Hidden::class,
         Statamic\Fieldtypes\Integer::class => Aerni\LivewireForms\Fields\Integer::class,
         Statamic\Fieldtypes\Radio::class => Aerni\LivewireForms\Fields\Radio::class,
@@ -23,7 +24,6 @@ return [
         Statamic\Fieldtypes\Text::class => Aerni\LivewireForms\Fields\Text::class,
         Statamic\Fieldtypes\Textarea::class => Aerni\LivewireForms\Fields\Textarea::class,
         Statamic\Fieldtypes\Toggle::class => Aerni\LivewireForms\Fields\Toggle::class,
-        Statamic\Fieldtypes\Dictionary::class => Aerni\LivewireForms\Fields\Dictionary::class,
     ],
 
     /*

--- a/config/livewire-forms.php
+++ b/config/livewire-forms.php
@@ -23,6 +23,7 @@ return [
         Statamic\Fieldtypes\Text::class => Aerni\LivewireForms\Fields\Text::class,
         Statamic\Fieldtypes\Textarea::class => Aerni\LivewireForms\Fields\Textarea::class,
         Statamic\Fieldtypes\Toggle::class => Aerni\LivewireForms\Fields\Toggle::class,
+        Statamic\Fieldtypes\Dictionary::class => Aerni\LivewireForms\Fields\Dictionary::class,
     ],
 
     /*

--- a/resources/views/default/fields/dictionary.blade.php
+++ b/resources/views/default/fields/dictionary.blade.php
@@ -1,0 +1,1 @@
+@include('livewire.forms.default.fields.select')

--- a/resources/views/default/fields/dictionary.blade.php
+++ b/resources/views/default/fields/dictionary.blade.php
@@ -1,1 +1,1 @@
-@include('livewire.forms.default.fields.select')
+@formView('fields.select')

--- a/src/Fields/Dictionary.php
+++ b/src/Fields/Dictionary.php
@@ -2,12 +2,7 @@
 
 namespace Aerni\LivewireForms\Fields;
 
-use Aerni\LivewireForms\Fields\Select;
-use Statamic\Dictionaries\Dictionary as DictionaryInstance;
-use Statamic\Exceptions\DictionaryNotFoundException;
-use Statamic\Exceptions\UndefinedDictionaryException;
 use Statamic\Facades\Dictionary as Dictionaries;
-use Statamic\Support\Arr;
 
 class Dictionary extends Select
 {
@@ -18,15 +13,12 @@ class Dictionary extends Select
         return $multiple ?? is_null($this->max_items) || $this->max_items > 1;
     }
 
-    public function dictionary(): ?DictionaryInstance
+    protected function optionsProperty(?array $options = null): array
     {
         $config = is_array($config = $this->field->get('dictionary')) ? $config : ['type' => $config];
 
-        return Dictionaries::find($config['type'], $config);
-    }
+        $dictionary = Dictionaries::find($config['type'], $config);
 
-    public function optionsProperty(?array $options = null): array
-    {
-        return $this->dictionary()?->options() ?? [];
+        return $dictionary?->options() ?? [];
     }
 }

--- a/src/Fields/Dictionary.php
+++ b/src/Fields/Dictionary.php
@@ -18,23 +18,15 @@ class Dictionary extends Select
         return $multiple ?? is_null($this->max_items) || $this->max_items > 1;
     }
 
-    public function dictionary(): DictionaryInstance
+    public function dictionary(): ?DictionaryInstance
     {
         $config = is_array($config = $this->field->get('dictionary')) ? $config : ['type' => $config];
 
-        if (! $handle = Arr::pull($config, 'type')) {
-            throw new UndefinedDictionaryException;
-        }
-
-        if ($dictionary = Dictionaries::find($handle, $config)) {
-            return $dictionary;
-        }
-
-        throw new DictionaryNotFoundException($handle);
+        return Dictionaries::find($config['type'], $config);
     }
 
     public function optionsProperty(?array $options = null): array
     {
-        return $this->dictionary()->options();
+        return $this->dictionary()?->options() ?? [];
     }
 }

--- a/src/Fields/Dictionary.php
+++ b/src/Fields/Dictionary.php
@@ -15,7 +15,7 @@ class Dictionary extends Select
 
     protected function multipleProperty(?bool $multiple = null): bool
     {
-        return $multiple ?? (int) $this->max_items > 1;
+        return $multiple ?? is_null($this->max_items) || $this->max_items > 1;
     }
 
     public function dictionary(): DictionaryInstance

--- a/src/Fields/Dictionary.php
+++ b/src/Fields/Dictionary.php
@@ -20,9 +20,7 @@ class Dictionary extends Select
 
     public function dictionary(): DictionaryInstance
     {
-        $config = $this->field->config();
-        $config = is_array($config) ? Arr::get($config, 'dictionary') : $config;
-        $config = is_array($config) ? $config : ['type' => $config];
+        $config = is_array($config = $this->field->get('dictionary')) ? $config : ['type' => $config];
 
         if (! $handle = Arr::pull($config, 'type')) {
             throw new UndefinedDictionaryException;

--- a/src/Fields/Dictionary.php
+++ b/src/Fields/Dictionary.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Aerni\LivewireForms\Fields;
+
+use Aerni\LivewireForms\Fields\Select;
+use Statamic\Dictionaries\Dictionary as DictionaryInstance;
+use Statamic\Exceptions\DictionaryNotFoundException;
+use Statamic\Exceptions\UndefinedDictionaryException;
+use Statamic\Facades\Dictionary as Dictionaries;
+use Statamic\Support\Arr;
+
+class Dictionary extends Select
+{
+    protected string $view = 'dictionary';
+
+    protected function multipleProperty(?bool $multiple = null): bool
+    {
+        return $multiple ?? (int) $this->max_items > 1;
+    }
+
+    public function dictionary(): DictionaryInstance
+    {
+        $config = $this->field->config();
+        $config = is_array($config) ? Arr::get($config, 'dictionary') : $config;
+        $config = is_array($config) ? $config : ['type' => $config];
+
+        if (! $handle = Arr::pull($config, 'type')) {
+            throw new UndefinedDictionaryException;
+        }
+
+        if ($dictionary = Dictionaries::find($handle, $config)) {
+            return $dictionary;
+        }
+
+        throw new DictionaryNotFoundException($handle);
+    }
+
+    public function optionsProperty(?array $options = null): array
+    {
+        return $this->dictionary()->options();
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Aerni\LivewireForms;
 
 use Aerni\LivewireForms\Facades\Captcha;
+use Aerni\LivewireForms\Facades\ViewManager;
 use Aerni\LivewireForms\Livewire\BaseForm;
 use Aerni\LivewireForms\Livewire\DynamicForm;
 use Aerni\LivewireForms\Livewire\Synthesizers\FieldSynth;
@@ -95,7 +96,7 @@ class ServiceProvider extends AddonServiceProvider
                 'type' => 'select',
                 'display' => __('View'),
                 'instructions' => __('Choose the view for this form.'),
-                'options' => $this->viewOptions(),
+                'options' => ViewManager::views(),
                 'clearable' => true,
                 'width' => 50,
             ],
@@ -103,7 +104,7 @@ class ServiceProvider extends AddonServiceProvider
                 'type' => 'select',
                 'display' => __('Theme'),
                 'instructions' => __('Choose the theme for this form.'),
-                'options' => $this->themeOptions(),
+                'options' => ViewManager::themes(),
                 'clearable' => true,
                 'width' => 50,
             ],
@@ -115,33 +116,5 @@ class ServiceProvider extends AddonServiceProvider
         ]);
 
         return $this;
-    }
-
-    protected function viewOptions(): ?array
-    {
-        $path = resource_path('views/'.config('livewire-forms.view_path'));
-
-        if (! File::isDirectory($path)) {
-            return null;
-        }
-
-        return collect(File::files($path))
-            ->map(fn ($file) => Str::before($file->getBasename(), '.'))
-            ->mapWithKeys(fn ($view) => [$view => str($view)->replace(['_', '-'], ' ')->title()->toString()])
-            ->all();
-    }
-
-    protected function themeOptions(): ?array
-    {
-        $path = resource_path('views/'.config('livewire-forms.view_path'));
-
-        if (! File::isDirectory($path)) {
-            return null;
-        }
-
-        return collect(File::directories($path))
-            ->map(fn ($directory) => basename($directory))
-            ->mapWithKeys(fn ($theme) => [$theme => str($theme)->replace(['_', '-'], ' ')->title()->toString()])
-            ->all();
     }
 }

--- a/src/UpdateScripts/AddDictionaryFieldView.php
+++ b/src/UpdateScripts/AddDictionaryFieldView.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Aerni\LivewireForms\UpdateScripts;
+
+use Illuminate\Support\Facades\File;
+use Statamic\UpdateScripts\UpdateScript;
+use Aerni\LivewireForms\Facades\ViewManager;
+
+class AddDictionaryFieldView extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        return $this->isUpdatingTo('9.6.0');
+    }
+
+    public function update()
+    {
+        collect(ViewManager::themes())
+            ->each(function ($name, $handle) {
+                $view = ViewManager::viewPath("{$handle}/fields/dictionary.blade.php");
+                File::copy(__DIR__.'/../../resources/views/default/fields/dictionary.blade.php', resource_path("views/{$view}"));
+            });
+
+        $this->console()->info('Added dictionary field view.');
+    }
+}

--- a/src/ViewManager.php
+++ b/src/ViewManager.php
@@ -2,6 +2,9 @@
 
 namespace Aerni\LivewireForms;
 
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\File;
+
 class ViewManager
 {
     public function viewPath(string $view): string
@@ -48,5 +51,33 @@ class ViewManager
     public function defaultTheme(): string
     {
         return config('livewire-forms.theme', 'default');
+    }
+
+    public function views(): ?array
+    {
+        $path = resource_path('views/'.config('livewire-forms.view_path'));
+
+        if (! File::isDirectory($path)) {
+            return null;
+        }
+
+        return collect(File::files($path))
+            ->map(fn ($file) => Str::before($file->getBasename(), '.'))
+            ->mapWithKeys(fn ($view) => [$view => str($view)->replace(['_', '-'], ' ')->title()->toString()])
+            ->all();
+    }
+
+    public function themes(): ?array
+    {
+        $path = resource_path('views/'.config('livewire-forms.view_path'));
+
+        if (! File::isDirectory($path)) {
+            return null;
+        }
+
+        return collect(File::directories($path))
+            ->map(fn ($directory) => basename($directory))
+            ->mapWithKeys(fn ($theme) => [$theme => str($theme)->replace(['_', '-'], ' ')->title()->toString()])
+            ->all();
     }
 }


### PR DESCRIPTION
Add support for Dictionary Fieldtype on the front-end forms. It supports all available Dictionaries in Statamic and all options to customize the `<select>` tag.

![image](https://github.com/user-attachments/assets/3e512d31-4f56-4ead-89e7-8546be1e36ad)

![image](https://github.com/user-attachments/assets/e156c8b5-18aa-4a0d-9dac-9b97639f5e1f)

![image](https://github.com/user-attachments/assets/9985b8c5-a977-4c20-8414-10e57813d7f5)

