### PR TITLE
Merge default field models

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -34,7 +34,7 @@ class ServiceProvider extends AddonServiceProvider
     public function bootAddon()
     {
         $this
-            ->bootModelsConfig()
+            ->bootFieldModels()
             ->bootBladeDirectives()
             ->bootValidators()
             ->bootLivewire()
@@ -42,7 +42,7 @@ class ServiceProvider extends AddonServiceProvider
             ->bootFormConfigFields();
     }
 
-    protected function bootModelsConfig(): self
+    protected function bootFieldModels(): self
     {
         $defaultModels = data_get(require(__DIR__.'/../config/livewire-forms.php'), 'models');
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -34,11 +34,23 @@ class ServiceProvider extends AddonServiceProvider
     public function bootAddon()
     {
         $this
+            ->bootModelsConfig()
             ->bootBladeDirectives()
             ->bootValidators()
             ->bootLivewire()
             ->bootSelectableFieldtypes()
             ->bootFormConfigFields();
+    }
+
+    protected function bootModelsConfig(): self
+    {
+        $defaultModels = data_get(require(__DIR__.'/../config/livewire-forms.php'), 'models');
+
+        $userModels = config('livewire-forms.models');
+
+        config()->set('livewire-forms.models', array_merge($defaultModels, $userModels));
+
+        return $this;
     }
 
     protected function bootBladeDirectives(): self


### PR DESCRIPTION
This PR ensures that the default field models are always available to the user. This allows us to introduce new field models without the user having to update their published config.