### PR TITLE
Fix publishable assets

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -27,16 +27,9 @@ class ServiceProvider extends AddonServiceProvider
         Fieldtypes\Captcha::class,
     ];
 
-    protected $scripts = [
-        __DIR__.'/../resources/dist/js/livewire-forms.js',
-        __DIR__.'/../resources/dist/js/form.js',
-        __DIR__.'/../resources/dist/js/filepond.js',
-        __DIR__.'/../resources/dist/js/grecaptcha.js',
-    ];
-
-    protected $stylesheets = [
-        __DIR__.'/../resources/dist/css/livewire-forms.css',
-        __DIR__.'/../resources/dist/css/filepond.css',
+    protected $publishables = [
+        __DIR__.'/../resources/dist/js' => 'js',
+        __DIR__.'/../resources/dist/css' => 'css',
     ];
 
     public function bootAddon()


### PR DESCRIPTION
This PR closes #94 by using `publishables` instead of `scripts` and `stylesheets`. Turns out that `scripts` and `stylesheets` are loaded in the CP, whereas `publishables` simply makes the assets publishable. Which is what we want.