### PR TITLE
Don’t show separator of hidden steps

### DIFF
--- a/resources/views/default/layouts/navigation.blade.php
+++ b/resources/views/default/layouts/navigation.blade.php
@@ -5,6 +5,10 @@
             wire:key="{{ $step->id() }}-navigation"
             class="flex items-center whitespace-nowrap gap-x-3"
         >
+            @if(!$loop->first)
+                <span class="text-gray-300 select-none" aria-hidden="true">/</span>
+            @endif
+
             <button
                 type="button"
                 class="
@@ -23,10 +27,6 @@
             >
                 {{ $step->display() }}
             </button>
-
-            @if(!$loop->last)
-                <span class="text-gray-300 select-none" aria-hidden="true">/</span>
-            @endif
         </li>
     @endforeach
 </ol>


### PR DESCRIPTION
This PR fixes a small styling issue that would cause the steps separator in the wizard navigation to show for conditionally hidden steps.

**Before:**
![CleanShot 2025-03-28 at 11 41 04@2x](https://github.com/user-attachments/assets/bef17bd9-bcd7-47f3-915f-45291f07fa87)

**After:**
![CleanShot 2025-03-28 at 11 41 49@2x](https://github.com/user-attachments/assets/b5702a2d-a2f4-42eb-8093-4387cc08695e)
