### PR TITLE
Change mimes to be an array

### DIFF
--- a/src/Fields/Assets.php
+++ b/src/Fields/Assets.php
@@ -55,7 +55,8 @@ class Assets extends Field
                 $rule instanceof ImageRule => ['image/*'],
                 $rule instanceof MimetypesRule => invade($rule)->parameters,
                 $rule instanceof MimesRule => collect(invade($rule)->parameters)
-                    ->flatMap(fn ($mime) => (new MimeTypes)->getMimeTypes($mime)),
+                    ->flatMap(fn ($mime) => (new MimeTypes)->getMimeTypes($mime))
+                    ->all(),
                 default => null,
             })
             ->filter()


### PR DESCRIPTION
This was causing an error when using the mimes rule.  Something further up the line expects it to be an array here not a collection.

You can test this by adding an asset field and then adding a validation rule like `mimes:pdf,jpg,jpeg` and try to load the page with the form on it.